### PR TITLE
Clear Imap Errors

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -54,7 +54,9 @@ class Mailbox extends component{
 	protected function initImapStream() {
 		$imapStream = @imap_open($this->imapPath, $this->imapLogin, $this->imapPassword, $this->imapOptions, $this->imapRetriesNum, $this->imapParams);
 		if(!$imapStream) {
-			throw new Exception('Connection error: ' . imap_last_error());
+			$lastError = imap_last_error();
+			imap_errors();
+			throw new Exception('Connection error: ' . $lastError);
 		}
 		return $imapStream;
 	}


### PR DESCRIPTION
Clear imap errors. If do not clear then imap errors are shown at the end of php script execution even if we tried to catch all exceptions.
