### PR TITLE
Fixed default argument for setConnectionArgs method

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -22,17 +22,17 @@ class Mailbox extends component
 	protected $attachmentsDir;
 	protected $decodeMimeStr = true;
 
-	/**
-	 * Set custom connection arguments of imap_open method. See http://php.net/imap_open
-	 * @param int $options
-	 * @param int $retriesNum
-	 * @param array $params
-	 */
-	public function setConnectionArgs($options = 0, $retriesNum = 0, array $params = null) {
-		$this->imapOptions = $options;
-		$this->imapRetriesNum = $retriesNum;
-		$this->imapParams = $params;
-	}
+    /**
+     * Set custom connection arguments of imap_open method. See http://php.net/imap_open
+     * @param int $options
+     * @param int $retriesNum
+     * @param array $params
+     */
+    public function setConnectionArgs($options = 0, $retriesNum = 0, array $params = []) {
+        $this->imapOptions = $options;
+        $this->imapRetriesNum = $retriesNum;
+        $this->imapParams = $params;
+    }
 
 	/**
 	 * Get IMAP mailbox connection stream


### PR DESCRIPTION
If you use `setConnectionArgs` and not ask the last argument, the error occurs types to be transferred.
```php
$services = new ServiceLocator();
$imap = new Imap(ArrayHelper::getValue(Yii::$app->params, 'TEST', []));
$services->set('imap', $imap);
$imap->createConnection();
$imap->setConnectionArgs(OP_READONLY);
```
https://www.php.net/manual/en/function.imap-open.php